### PR TITLE
Added a couple of missing autocorrect flags

### DIFF
--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -133,7 +133,8 @@ def lastfm(text, nick, db, bot, notice):
 def getartisttags(artist, bot):
     tag_list = []
     api_key = bot.config.get("api_keys", {}).get("lastfm")
-    params = { 'method': 'artist.getTopTags', 'api_key': api_key, 'artist': artist }
+    params = { 'method': 'artist.getTopTags', 'api_key': api_key, 'artist': artist,
+            'autocorrect': '1'}
     request = requests.get(api_url, params = params)
     tags = request.json()
 

--- a/plugins/lastfm.py
+++ b/plugins/lastfm.py
@@ -150,7 +150,7 @@ def getsimilarartists(artist, bot):
     artist_list = []
     api_key = bot.config.get('api_keys', {}).get('lastfm')
     params = { 'method': 'artist.getsimilar', 'api_key': api_key,
-            'artist': artist }
+            'artist': artist, 'autocorrect': '1' }
     request = requests.get(api_url, params = params)
     similar = request.json()
 


### PR DESCRIPTION
### Before

13:50 @Mike .band Destroyer 666
13:50 < nergal> (Mike) Destroyer 666 have 2236809 plays and 55899 listeners. Similar artists include no similar artists. Tags: (black metal, blackened thrash metal, thrash metal, death metal).
### After

13:52 @Mike .band Destroyer 666
13:52 < nergal_test> (Mike) Destroyer 666 have 2236809 plays and 55899 listeners. Similar artists include Desaster, Nifelheim, Gospel of the Horns, Aura Noir. Tags: (black metal, blackened thrash metal, thrash metal, death metal).
